### PR TITLE
Make stack configurable

### DIFF
--- a/ci/build-binaries/task.sh
+++ b/ci/build-binaries/task.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+export CI_ROOT=$PWD
+export ROOT="$PWD/go/src/github.com/cloudfoundry-incubator"
+source "eirinifs/ci/scripts/common.sh"
+
+main(){
+  start-docker
+  setup-gopath
+  build-binaries
+}
+
+build-binaries() {
+  pushd "$ROOT/eirinifs/launchcmd" || exit 1
+    GOOS=linux go build -a -o "$CI_ROOT/binaries/launch"
+  popd
+
+  pushd "$ROOT/eirinifs/buildpackapplifecycle/launcher" || exit 1
+    echo "package main" > package.go # https://golang.org/cmd/go/#hdr-Import_path_checking
+    GOOS=linux CGO_ENABLED=0 go build -a -installsuffix static -o "$CI_ROOT/binaries/launcher"
+  popd
+}
+
+main "$@"

--- a/ci/build-binaries/task.yml
+++ b/ci/build-binaries/task.yml
@@ -8,11 +8,10 @@ image_resource:
 
 inputs:
 - name: eirinifs
-- name: binaries
 
 outputs:
-- name: go/src/github.com/cloudfoundry-incubator/eirinifs/image/
+- name: binaries
 
 run:
-  path: eirinifs/ci/build-eirinifs/task.sh
+  path: eirinifs/ci/build-binaries/task.sh
 

--- a/ci/build-eirinifs/task.sh
+++ b/ci/build-eirinifs/task.sh
@@ -1,58 +1,22 @@
 #!/bin/bash
 
 set -euo pipefail
+export CI_ROOT=$PWD
 export ROOT="$PWD/go/src/github.com/cloudfoundry-incubator"
+source "eirinifs/ci/scripts/common.sh"
 
 main(){
   start-docker
   setup-gopath
-  build-binaries
   export-eirinifs
   create-checksum-file
 }
 
-start-docker() {
-  echo 'DOCKER_OPTS="--data-root /scratch/docker --max-concurrent-downloads 10"' > /etc/default/docker
-  service docker start
-  trap 'service docker stop' EXIT
-
-  local -r max_retries=20
-  local current_retries=0
-  until docker-running; do
-    if [ "$current_retries" -gt "$max_retries" ]; then
-        echo "Failed to start docker daemon after $max_retries retries"
-        exit 1
-    fi
-    ((++current_retries))
-    sleep 0.5
-  done
-}
-
-docker-running() {
-  docker stats --no-stream > /dev/null 2>&1
-}
-
-setup-gopath() {
-  mkdir -p "$ROOT"
-  export GOPATH=$PWD/go
-  export PATH=$PATH:$GOPATH/bin
-  cp -r eirinifs "$ROOT"
-}
-
-build-binaries() {
-  pushd "$ROOT/eirinifs/launchcmd" || exit 1
-    GOOS=linux go build -a -o "$ROOT/eirinifs/image/launch"
-  popd
-
-  pushd "$ROOT/eirinifs/buildpackapplifecycle/launcher" || exit 1
-    echo "package main" > package.go # https://golang.org/cmd/go/#hdr-Import_path_checking
-    GOOS=linux CGO_ENABLED=0 go build -a -installsuffix static -o "$ROOT/eirinifs/image/launcher"
-  popd
-}
-
 export-eirinifs() {
   pushd "$ROOT/eirinifs/image" || exit 1
-    docker build -t "eirini/launch" .
+    cp ${CI_ROOT}/binaries/launcher ./
+    cp ${CI_ROOT}/binaries/launch ./
+    docker build --build-arg baseimage=${BASEIMAGE} -t "eirini/launch" .
     docker run -it -d --name="eirini-launch" eirini/launch /bin/bash
     docker export eirini-launch -o eirinifs.tar
   popd

--- a/ci/build-sle15/task.sh
+++ b/ci/build-sle15/task.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euo pipefail
+export CI_ROOT=$PWD
+export ROOT="$PWD/go/src/github.com/cloudfoundry-incubator"
+source "eirinifs/ci/scripts/common.sh"
+
+main(){
+  start-docker
+  setup-gopath
+  export-sle15
+}
+
+export-sle15() {
+  wget $(cat sle15-release/body | grep -o "https:\/\/.*\.tgz") # Get the release tarball
+  tar --to-command='tar xfz -' -xvf *.tgz packages/sle15.tgz # Extract the rootfs
+
+  export BASEIMAGE="registry.suse.com/cap/sle15"
+  cat rootfs/* | docker import - ${BASEIMAGE}
+
+  pushd "$ROOT/eirinifs/image" || exit 1
+    cp ${CI_ROOT}/binaries/* ./
+    docker build --build-arg baseimage=${BASEIMAGE} -t "eirini/launch" .
+    docker run -it -d --name="eirini-launch" eirini/launch /bin/bash
+    docker export eirini-launch -o sle15.tar
+  popd
+}
+
+main "$@"
+

--- a/ci/build-sle15/task.yml
+++ b/ci/build-sle15/task.yml
@@ -1,0 +1,19 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: eirini/fsbuilder
+
+inputs:
+- name: sle15-release
+- name: eirinifs
+- name: binaries
+
+outputs:
+- name: go/src/github.com/cloudfoundry-incubator/eirinifs/image/
+
+run:
+  path: eirinifs/ci/build-sle15/task.sh
+

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -46,6 +46,9 @@ jobs:
   - put: eirinifs-version
     params:
       file: eirinifs-version/version
+  - task: build binaries
+    privileged: true
+    file: eirinifs/ci/build-binaries/task.yml
   - task: build eirinifs
     privileged: true
     file: eirinifs/ci/build-eirinifs/task.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -40,6 +40,8 @@ jobs:
     passed: [ run-tests ]
   - get: cflinuxfs3-image
     trigger: true
+  - get: sle15-release
+    trigger: true
   - get: eirinifs-version
     params:
       bump: major
@@ -52,6 +54,9 @@ jobs:
   - task: build eirinifs
     privileged: true
     file: eirinifs/ci/build-eirinifs/task.yml
+  - task: build sle15
+    privileged: true
+    file: eirinifs/ci/build-sle15/task.yml
   - task: create-release-notes
     file: eirinifs/ci/create-release-notes/task.yml
   - put: eirinifs-release
@@ -141,6 +146,11 @@ resources:
   type: docker-image
   source:
     repository: cloudfoundry/cflinuxfs3
+- name: sle15-release
+  type: github-release
+  source:
+    owner: SUSE
+    repository: cf-sle15-release
 - name: eirinifs-release
   type: github-release
   source:

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+start-docker() {
+  echo 'DOCKER_OPTS="--data-root /scratch/docker --max-concurrent-downloads 10"' > /etc/default/docker
+  service docker start
+  trap 'service docker stop' EXIT
+
+  local -r max_retries=20
+  local current_retries=0
+  until docker-running; do
+    if [ "$current_retries" -gt "$max_retries" ]; then
+        echo "Failed to start docker daemon after $max_retries retries"
+        exit 1
+    fi
+    ((++current_retries))
+    sleep 0.5
+  done
+}
+
+docker-running() {
+  docker stats --no-stream > /dev/null 2>&1
+}
+
+setup-gopath() {
+  mkdir -p "$ROOT"
+  export GOPATH=$PWD/go
+  export PATH=$PATH:$GOPATH/bin
+  cp -r eirinifs "$ROOT"
+}

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,5 @@
-FROM cloudfoundry/cflinuxfs3
+ARG baseimage=cloudfoundry/cflinuxfs3
+FROM ${baseimage}
 
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64
 RUN chmod +x /usr/local/bin/dumb-init


### PR DESCRIPTION
We split this Pull Request in 3 commits:

- The first one, extracts the building of binaries in a separate task so that the binaries can be reused by another task (see the next bullet)
- The second commit just introduces the task to build a stack based on sle15.
- The last commit uses the above task in the pipeline.

We leave it up to you to decide up to which commit you want to merge and we will keep the rest in a fork. Building the sle15 stack even if we don't consume it or not push it to any bucket makes sense because it will let us know immediately if changes in the pipeline break our builds. If you can't spare the resources then let's just merge the first commit so we can reuse part of the scripts in this repository. This will make our rebases easier.